### PR TITLE
Kraken: no more name and uri in journey_pattern_key

### DIFF
--- a/source/kraken/fill_disruption_from_chaos.cpp
+++ b/source/kraken/fill_disruption_from_chaos.cpp
@@ -518,7 +518,7 @@ struct vehicle_journey_impactor {
   void complete() {
       complete_impl(vj_discrete_to_be_updated);
       complete_impl(vj_frequency_to_be_updated);
-  };
+  }
 
   bool is_impacted(const nt::VehicleJourney& vj) const{
       for (auto period : impact->application_periods) {
@@ -556,7 +556,7 @@ struct vehicle_journey_impactor {
           }
       }
       auto jp_key = nt::JourneyPatternKey{jp, std::move(stop_points_for_key)};
-      return pt_data.get_or_create_journey_pattern(jp_key);
+      return pt_data.get_or_create_journey_pattern(jp_key, jp.name, jp.uri);
   }
 
   template<typename T>
@@ -741,6 +741,7 @@ struct add_impacts_visitor : public apply_impacts_visitor {
                 impact->impacted_journey_patterns.erase(it);
             }
         });
+        pt_data.remove_journey_pattern_from_jp_pool(*jp);
     }
 
 

--- a/source/type/pt_data.h
+++ b/source/type/pt_data.h
@@ -162,21 +162,7 @@ struct PT_Data : boost::noncopyable{
         return nb;
     }
 
-    type::ValidityPattern* get_or_create_validity_pattern(const ValidityPattern& vp_ref) {
-        for (auto vp : validity_patterns) {
-            if (vp->days == vp_ref.days && vp->beginning_date == vp_ref.beginning_date) {
-                return vp;
-            }
-        }
-        auto vp = new nt::ValidityPattern();
-        vp->idx = validity_patterns.size();
-        vp->uri = make_adapted_uri(vp->uri);
-        vp->beginning_date = vp_ref.beginning_date;
-        vp->days = vp_ref.days;
-        validity_patterns.push_back(vp);
-        validity_patterns_map[vp->uri] = vp;
-        return vp;
-    }
+    type::ValidityPattern* get_or_create_validity_pattern(const ValidityPattern& vp_ref);
 
     /** Retrouve un élément par un attribut arbitraire de type chaine de caractères
       *
@@ -192,7 +178,9 @@ struct PT_Data : boost::noncopyable{
 
     const StopPointConnection*
     get_stop_point_connection(const StopPoint& from, const StopPoint& to) const;
-    nt::JourneyPattern* get_or_create_journey_pattern (const JourneyPatternKey& key);
+    nt::JourneyPattern* get_or_create_journey_pattern (const JourneyPatternKey& key,
+                                                       const std::string& name,
+                                                       const std::string& uri);
     void remove_journey_pattern_from_jp_pool(const JourneyPattern& jp);
     ~PT_Data();
 

--- a/source/type/type.cpp
+++ b/source/type/type.cpp
@@ -790,24 +790,25 @@ JourneyPatternKey::JourneyPatternKey(const JourneyPattern& jp):
         route(jp.route),
         physical_mode(jp.physical_mode),
         commercial_mode(jp.commercial_mode),
-        odt_properties(jp.odt_properties),
-        name(jp.name),
-        uri(jp.uri){}
+        odt_properties(jp.odt_properties){}
 
 bool JourneyPatternKey::operator==(const JourneyPatternKey& other) const{
-    return hash_value(*this) == hash_value(other);
+    return is_frequence == other.is_frequence &&
+           route == other.route &&
+           physical_mode == other.physical_mode &&
+           commercial_mode == other.commercial_mode &&
+           odt_properties == other.odt_properties &&
+           stop_points == other.stop_points;
 }
 
 std::size_t hash_value(const JourneyPatternKey& key){
     std::size_t seed{0};
-    boost::hash_combine(seed, key.stop_points);
     boost::hash_combine(seed, key.is_frequence);
     boost::hash_combine(seed, key.route);
     boost::hash_combine(seed, key.physical_mode);
     boost::hash_combine(seed, key.commercial_mode);
     boost::hash_combine(seed, key.odt_properties.odt_properties.to_string());
-    boost::hash_combine(seed, key.name);
-    boost::hash_combine(seed, key.uri);
+    boost::hash_combine(seed, key.stop_points);
     return seed;
 }
 

--- a/source/type/type.h
+++ b/source/type/type.h
@@ -582,6 +582,9 @@ struct hasOdtProperties {
     void operator|=(const type::hasOdtProperties& other) {
         odt_properties |= other.odt_properties;
     }
+    bool operator==(const type::hasOdtProperties& other) const {
+        return odt_properties == other.odt_properties;
+    }
 
     void reset() { odt_properties.reset(); }
     void set_estimated(const bool val = true) { odt_properties.set(ESTIMATED_ODT, val); }
@@ -1145,8 +1148,6 @@ struct JourneyPatternKey {
     PhysicalMode* physical_mode = nullptr;
     CommercialMode* commercial_mode = nullptr;
     hasOdtProperties odt_properties{};
-    std::string name{};
-    std::string uri{};
     std::vector<StopPoint*> stop_points{};
 
     explicit JourneyPatternKey(const JourneyPattern& jp, std::vector<StopPoint*>&& sps);


### PR DESCRIPTION
- remove name and uri from jp_key
- debug on jp_pool management
- light refactors
